### PR TITLE
Remove typo and duplicate purge command

### DIFF
--- a/debloat-mint.sh
+++ b/debloat-mint.sh
@@ -21,10 +21,9 @@ if [ $? = 0 ]; then
 	sudo apt purge xreader -y
 	sudo apt purge onboard -y
 	sudo apt purge gnome-calendar -y
-z	sudo apt purge celluloid -y
+	sudo apt purge celluloid -y
 	sudo apt purge gnome-logs -y
 	sudo apt purge gnome-power-manager -y
-	sudo apt purge onboard -y
 	sudo apt purge warpinator -y
 
 	sudo apt autoremove -y && sudo apt clean


### PR DESCRIPTION
Removed a random "z" character on line 24 that silently prevented celluloid from being removed.
Also removed a duplicate call to purging onboard on line 27.